### PR TITLE
Make fish a valid target for Robust Digestion pawns

### DIFF
--- a/1.5/Defs/ThingDefs_Items/Items_Resource_Fish.xml
+++ b/1.5/Defs/ThingDefs_Items/Items_Resource_Fish.xml
@@ -22,10 +22,11 @@
 		</statBases>
 		<ingestible>
 			<foodType>Meat</foodType>
-			<preferability>DesperateOnly</preferability>
+			<preferability>RawBad</preferability>
 			<ingestEffect>EatMeat</ingestEffect>
 			<ingestSound>RawMeat_Eat</ingestSound>		
 		</ingestible>
+		<socialPropernessMatters>true</socialPropernessMatters>
 		<thingCategories>
 			<li>VCEF_RawFishCategory</li>
 		</thingCategories>


### PR DESCRIPTION
Pawns with the Robust Digestion Gene are able to eat raw food (incl. fish) efficiently and without a mood penalty. With standard vanilla options, they will seek raw food out when hungry to eat that. But with fish from VE Fishing, they won't until they become desperate (0% food bar), which leads to extended periods of time where mood is lowered.

This patch makes it so that fish is an acceptable choice for pawns that have the robust digestion gene.